### PR TITLE
responses() now accepts design_object or survey ID

### DIFF
--- a/R/choices.R
+++ b/R/choices.R
@@ -35,8 +35,12 @@ parse_choices <- function(choice_tree) {
   
   # the names in choice_tree are question ids, which should be unique
   stopifnot(identical(names(choice_tree), unique(names(choice_tree))))
-  x <- data.table::rbindlist(lapply(choice_tree, unlist, recursive = FALSE),
-    fill = TRUE, idcol = "question_id")
+
+  # deal with case of MC with "other" option
+  z <- lapply(choice_tree, unlist, recursive = FALSE)
+  z <- lapply(z, function(y) lapply(y, function(z) if(!length(z)) z <- NA else z))
+  
+  x <- data.table::rbindlist(z, fill = TRUE, idcol = "question_id")
   x[, names(x) := lapply(.SD, as.character)]
   # x is now a wide table with columns like 9.description, 9.choiceText...
   x <- data.table::melt(x,

--- a/R/responses.R
+++ b/R/responses.R
@@ -20,7 +20,8 @@
 #' \code{useLabels} (exposed as argument \code{use_labels}), and \code{format},
 #' (which must be \code{json}).
 #'
-#' @param id A Qualtrics survey identifier.
+#' @param design_object A \code{\link{qualtrics_design-class}} object retrieved
+#' from Qualtrics by \code{\link{design}}.
 #' @param use_labels Use question labels and choice descriptions (default),
 #'   instead of question and identifiers.
 #' @param verbose Print progress.
@@ -32,7 +33,7 @@
 #' @importFrom utils unzip txtProgressBar setTxtProgressBar
 #' @importFrom jsonlite fromJSON
 #' @export
-responses <- function(id,
+responses <- function(design_object,
                      use_labels = TRUE,
                      verbose = FALSE, 
                      key = Sys.getenv("QUALTRICS_KEY"),
@@ -41,6 +42,14 @@ responses <- function(id,
 
   # Adapted from the Python example:
   # https://api.qualtrics.com/docs/response-exports
+
+  # Use the design object or ID depending what has been passed
+  if (!is.character(design_object)) {
+    assert_is_design(design_object)
+    id <- design_object$id
+  } else {
+    id <- design_object
+  }
 
   # requests() handles checking of key and subdomain arguments
   assertthat::assert_that(assertthat::is.string(id))


### PR DESCRIPTION
To stay consistent with the syntax of questions(), blocks(), and choices(), responses() has been changed to accept the design_object as the survey argument, and also is backwards compatible to accept the id of the design_object as a string which it was originally.